### PR TITLE
Docker build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,8 @@ jobs:
       - checkout
       # ... steps for building/testing app ...
 
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - setup_remote_docker
+          # docker_layer_caching: true
 
       # build and push Docker image
       - run: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,34 @@ version: 2.1
 orbs:
   # Declare a dependency on the welcome-orb
   welcome: circleci/welcome-orb@0.4.1
+
+jobs:
+  build:
+    docker:
+      - image: cimg/base:2020.01
+    steps:
+      - checkout
+      # ... steps for building/testing app ...
+
+      - setup_remote_docker:
+          docker_layer_caching: true
+
+      # build and push Docker image
+      - run: |
+          TAG=0.1.$CIRCLE_BUILD_NUM
+          docker build -t aaronsfishman/bov-tb:$TAG .
+          echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
+          docker push aaronsfishman/bov-tb:$TAG
+
+
 # Orchestrate or schedule a set of jobs
 workflows:
-  # Name the workflow "welcome"
-  welcome:
-    # Run the welcome/run job in its own container
+  build_docker:
     jobs:
-      - welcome/run
+      - build
+  # # Name the workflow "welcome"
+  # welcome:
+  #   # Run the welcome/run job in its own container
+  #   jobs:
+  #     - welcome/run
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,20 +1,16 @@
-# Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
-# Use a package of configuration called an orb.
-orbs:
-  # Declare a dependency on the welcome-orb
-  welcome: circleci/welcome-orb@0.4.1
 
 jobs:
+  # Docker image containing the nextflow pipeline
   build:
     docker:
+      # Circleci base ubuntu image
       - image: cimg/base:2020.01
+
     steps:
       - checkout
-      # ... steps for building/testing app ...
 
       - setup_remote_docker
-          # docker_layer_caching: true
 
       # build and push Docker image
       - run: |
@@ -23,15 +19,9 @@ jobs:
           echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
           docker push aaronsfishman/bov-tb:$TAG
 
-
-# Orchestrate or schedule a set of jobs
+# Orchestrates sets of jobs
 workflows:
-  build_docker:
+  build:
     jobs:
       - build
-  # # Name the workflow "welcome"
-  # welcome:
-  #   # Run the welcome/run job in its own container
-  #   jobs:
-  #     - welcome/run
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,6 @@ LABEL about.tags="Genomics, WGS"
 
 ################## DEPENDENCIES ######################
 
-RUN this_should_throw_an_error 
-
 # apt-get dependencies
 RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     openjdk-8-jdk \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ LABEL about.tags="Genomics, WGS"
 
 ################## DEPENDENCIES ######################
 
-RUN this_should_throw_an_error
+RUN this_should_throw_an_error 
 
 # apt-get dependencies
 RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ LABEL about.tags="Genomics, WGS"
 
 ################## DEPENDENCIES ######################
 
+RUN this_should_throw_an_error
+
 # apt-get dependencies
 RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     openjdk-8-jdk \

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,5 @@
 # **BovTB-nf**
 
-# Template:
 [![APHA-CSU](https://circleci.com/gh/APHA-CSU/BovTB-nf.svg?style=svg)](https://app.circleci.com/pipelines/github/APHA-CSU)
 
 ------------

--- a/Readme.md
+++ b/Readme.md
@@ -31,12 +31,17 @@ If required, there is simple script for installing the dependancies (helpfully c
 
 # Docker build
 
-Alternatively, the pipeline can run in an ubuntu image on docker. 
-To build the image:
-`docker build /PATH/TO/REPO/ -t bov-tb`
+Alternatively, the pipeline can run in a docker ubuntu image. 
 
-Run a docker container in bash:
-`docker run --rm -it bov-tb`
+Pull the latest (master) image from docker hub:
+> docker pull aaronsfishman/bov-tb:latest
+
+Then run the docker container in bash:
+> docker run --rm -it aaronsfishman/bov-tb:latest
+
+Or build and run the image directly from source
+> docker build /PATH/TO/REPO/ -t bov-tb
+> docker run --rm -it bov-tb
 
 -------------
 


### PR DESCRIPTION
This PR: 
- adds job to build the `Dockerfile` on CircleCI and push to dockerhub (like github for docker) with a branch specific tag. The plan is to have CircleCI pull the tag from dockerhub when running validation tests. 
- Removed welcome job 
- updated docker usage instructions in `Readme.md`

In addition to this code, I've also:
- Created a public repo on dockerhub for hosting pipeline images: https://hub.docker.com/r/aaronsfishman/bov-tb
- Setup an automated build on the dockerhub repo. Every time the `master` branch on github is updated, dockerhub will automatically rebuild master with the `latest` tag. Thus, calling `docker pull aaronsfishman/bov-tb:latest` downloads the latest pipeline. This way users (e.g. EC2) don't have to build the image. 
- Signed up a docker account named `aphacsubot`. This account provides the credentials for pushing docker images from CircleCI to dockerhub
- Installed CircleCI status checks on the github repo. The branches tab on github now displays a check or X that indicates if the CI tests pass (see attached image). It should also appear on the 'checks' tab of this PR. Check it out!

## Github Status Checks
<img width="1440" alt="Screenshot 2020-09-11 at 14 00 47" src="https://user-images.githubusercontent.com/6979169/92932174-694b9e80-f43c-11ea-8dd3-156fe052dd52.png">

## Dockerhub
<img width="1367" alt="Screenshot 2020-09-11 at 14 46 52" src="https://user-images.githubusercontent.com/6979169/92933180-d4e23b80-f43d-11ea-8aaa-b04f303a19c4.png">

## CircleCI
<img width="1437" alt="Screenshot 2020-09-11 at 14 47 17" src="https://user-images.githubusercontent.com/6979169/92933193-d9a6ef80-f43d-11ea-930c-f263b7a16a9c.png">
