### PR TITLE
Low qual flag

### DIFF
--- a/bin/ReadStats.sh
+++ b/bin/ReadStats.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #  ReadStats.sh
 #  
@@ -41,14 +41,14 @@ pair_id=$1
     mindepth=10 # require an average of at least 10 reads per site 
     minpc=60 # require at least 60% of data maps to genome
     minreads=600000 # require at least 600,000 raw reads per sample
-    minafttrim=80 # require at least 80% reads to pass quality filtering steps
+    minafttrim=60 # require at least 80% reads to pass quality filtering steps
 
 # This section assigns 'flags' based on the number of reads and the proportion mapping to reference genome
     
-    if [ ${avg_depth%%.*} -ge $mindepth ] && [ ${pc_mapped%%.*} -gt $minpc ]; then flag="Pass"
-        elif [ ${pc_aft_trim%%.*} -lt $minafttrim ] && [ ${avg_depth%%.*} -lt $mindepth ]; then flag="LowQualData"
-        elif [ ${avg_depth%%.*} -lt $mindepth ] && [ ${pc_mapped%%.*} -lt $minpc ] && [ $num_trim -gt $minreads ]; then flag="Comtaminated"
-        elif [ ${avg_depth%%.*} -lt $mindepth ] && [ $num_trim -lt $minreads ]; then flag="Insufficient_Data"
+    if [[ ${pc_aft_trim%%.*} -lt $minafttrim ]]; then flag="LowQualData"
+        elif [[ ${avg_depth%%.*} -ge $mindepth ]] && [[ ${pc_mapped%%.*} -gt $minpc ]]; then flag="Pass"
+        elif [[ ${avg_depth%%.*} -lt $mindepth ]] && [[ ${pc_mapped%%.*} -lt $minpc ]] && [[ $num_trim -gt $minreads ]]; then flag="Comtaminated"
+        elif [[ ${avg_depth%%.*} -lt $mindepth ]] && [[ $num_trim -lt $minreads ]]; then flag="InsufficientData"
 #        elif [ ${pc_mapped%%.*} -lt $minpc ] && [ $num_trim -gt $minreads ]; then flag="q_OtherMycobact"
         else flag="CheckRequired"
     fi

--- a/bin/ReadStats.sh
+++ b/bin/ReadStats.sh
@@ -41,10 +41,12 @@ pair_id=$1
     mindepth=10 # require an average of at least 10 reads per site 
     minpc=60 # require at least 60% of data maps to genome
     minreads=600000 # require at least 600,000 raw reads per sample
-    
+    minafttrim=80
+
 # This section assigns 'flags' based on the number of reads and the proportion mapping to reference genome
     
     if [ ${avg_depth%%.*} -ge $mindepth ] && [ ${pc_mapped%%.*} -gt $minpc ]; then flag="Pass"
+        elif [ ${pc_aft_trim%%.*} -lt $minafttrim ]; then flag="LowQualData"
         elif [ ${avg_depth%%.*} -lt $mindepth ] && [ ${pc_mapped%%.*} -lt $minpc ] && [ $num_trim -gt $minreads ]; then flag="Comtaminated"
         elif [ ${avg_depth%%.*} -lt $mindepth ] && [ $num_trim -lt $minreads ]; then flag="InsufficientData"
 #        elif [ ${pc_mapped%%.*} -lt $minpc ] && [ $num_trim -gt $minreads ]; then flag="q_OtherMycobact"

--- a/bin/ReadStats.sh
+++ b/bin/ReadStats.sh
@@ -46,9 +46,9 @@ pair_id=$1
 # This section assigns 'flags' based on the number of reads and the proportion mapping to reference genome
     
     if [ ${avg_depth%%.*} -ge $mindepth ] && [ ${pc_mapped%%.*} -gt $minpc ]; then flag="Pass"
-        elif [ ${pc_aft_trim%%.*} -lt $minafttrim ]; then flag="LowQualData"
+        elif [ ${pc_aft_trim%%.*} -lt $minafttrim ] && [ ${avg_depth%%.*} -lt $mindepth ]; then flag="LowQualData"
         elif [ ${avg_depth%%.*} -lt $mindepth ] && [ ${pc_mapped%%.*} -lt $minpc ] && [ $num_trim -gt $minreads ]; then flag="Comtaminated"
-        elif [ ${avg_depth%%.*} -lt $mindepth ] && [ $num_trim -lt $minreads ]; then flag="InsufficientData"
+        elif [ ${avg_depth%%.*} -lt $mindepth ] && [ $num_trim -lt $minreads ]; then flag="Insufficient_Data"
 #        elif [ ${pc_mapped%%.*} -lt $minpc ] && [ $num_trim -gt $minreads ]; then flag="q_OtherMycobact"
         else flag="CheckRequired"
     fi

--- a/bin/ReadStats.sh
+++ b/bin/ReadStats.sh
@@ -41,7 +41,7 @@ pair_id=$1
     mindepth=10 # require an average of at least 10 reads per site 
     minpc=60 # require at least 60% of data maps to genome
     minreads=600000 # require at least 600,000 raw reads per sample
-    minafttrim=80
+    minafttrim=80 # require at least 80% reads to pass quality filtering steps
 
 # This section assigns 'flags' based on the number of reads and the proportion mapping to reference genome
     

--- a/bin/ReadStats.sh
+++ b/bin/ReadStats.sh
@@ -41,7 +41,7 @@ pair_id=$1
     mindepth=10 # require an average of at least 10 reads per site 
     minpc=60 # require at least 60% of data maps to genome
     minreads=600000 # require at least 600,000 raw reads per sample
-    minafttrim=60 # require at least 80% reads to pass quality filtering steps
+    minafttrim=60 # require at least 60% reads to pass quality filtering steps
 
 # This section assigns 'flags' based on the number of reads and the proportion mapping to reference genome
     

--- a/tests/jobs/tinyreads.bash
+++ b/tests/jobs/tinyreads.bash
@@ -20,4 +20,4 @@ nextflowtest
 # Check results
 WGS_CLUSTER_CSV=$(print_todays_wgs_cluster)
 assert_first_csv_row $WGS_CLUSTER_CSV \
-    Outcome InsufficientData
+    Outcome LowQualData


### PR DESCRIPTION
Following on from the data I was looking at last week, I have added an additional flag to the ReadStats.sh script so that poor quality data is identified, and the reason for the problems can be tracked down.  The script now tests that the proportion of reads that get through the trimmomatic quality screening is >60% (anything below this suggests a problem with the sequencing instruments).  

I came across another issue which meant that any values below 1 caused an error when using the standard ```[``` command.  In Ubuntu #!/bin/sh calls dash by default, so now bash is called explicitly and ```[``` is replaced with ```[[```