### PR TITLE
Deploy to Dockerhub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,24 @@ commands:
       - store_artifacts:
           path: /artifacts/
 
+  build-and-push:
+    parameters:
+      tag:
+        description: Tag to push built docker image to
+        type: string
+
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run: |
+          TAG=<< parameters.tag >>
+          docker build -t aaronsfishman/bov-tb:$TAG -f ./docker/Dockerfile .
+          echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
+          docker push aaronsfishman/bov-tb:$TAG
+
 # Run tests under BovTB-nf/tests/jobs/ and store artifacts
 jobs:
-  # Docker image containing the nextflow pipeline
+  # Docker image containing the nextflow pipeline $CIRCLE_BRANCH
   build:
     docker:
       # Circleci base ubuntu image
@@ -28,11 +43,19 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - run: |
-          TAG=$CIRCLE_BRANCH
-          docker build -t aaronsfishman/bov-tb:$TAG -f ./docker/Dockerfile .
-          echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
-          docker push aaronsfishman/bov-tb:$TAG
+      - build-and-push:
+          tag: $CIRCLE_BRANCH
+
+  deploy: 
+    docker:
+      # Circleci base ubuntu image
+      - image: cimg/base:2020.01
+
+    steps:
+      - checkout
+      - setup_remote_docker
+      - build-and-push:
+          tag: latest
 
   tinyreads:
     executor: nf-pipeline

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
   build:
     docker:
       # Circleci base ubuntu image
-      - image: cimg/base:2020.01
+      - image: &build_img cimg/base:2020.01
 
     steps:
       - build-and-push:
@@ -47,7 +47,7 @@ jobs:
   deploy: 
     docker:
       # Circleci base ubuntu image
-      - image: cimg/base:2020.01
+      - image: *build_img
 
     steps:
       - build-and-push:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,8 +41,6 @@ jobs:
       - image: cimg/base:2020.01
 
     steps:
-      - checkout
-      - setup_remote_docker
       - build-and-push:
           tag: $CIRCLE_BRANCH
 
@@ -52,8 +50,6 @@ jobs:
       - image: cimg/base:2020.01
 
     steps:
-      - checkout
-      - setup_remote_docker
       - build-and-push:
           tag: latest
 
@@ -92,6 +88,13 @@ workflows:
   validation:
     jobs:
       - build
+
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
 
       - tinyreads:
           requires:


### PR DESCRIPTION
Dockerhub autobuild hasn't work since I moved the Dockerfile into the `/docker/` folder. I struggled to fix the dockerhub settings so instead I've made a deploy job on .circleci.

Now, every time we merge to master, `.circleci` pushes a docker image to dockerhub with the latest tag. 

When this branch is merged, the deploy job should run.