### PR TITLE
Thresholds

### DIFF
--- a/bTB-WGS_process.nf
+++ b/bTB-WGS_process.nf
@@ -192,7 +192,7 @@ process Mask {
 
 	"""
 	$dependpath/bedtools2/bin/bedtools genomecov -bga -ibam ${pair_id}.mapped.sorted.bam |
-	 grep -w "0\$" > ${pair_id}_zerocov.bed
+	 grep -w "0\$" | cat > ${pair_id}_zerocov.bed
 	cat ${pair_id}_zerocov.bed $rptmask | sort -k1,1 -k2,2n |
 	 $dependpath/bedtools2/bin/bedtools merge > ${pair_id}_RptZeroMask.bed
 	"""

--- a/bin/ReadStats.sh
+++ b/bin/ReadStats.sh
@@ -32,7 +32,7 @@ pair_id=$1
     num_uniq=$(($uniq_R1*2))
     num_trim=$(($trim_R1*2))
     pc_aft_dedup=$(echo "scale=2; ($num_uniq*100/$num_raw)" |bc)
-    pc_aft_trim=$(echo "scale=2; ($num_trim*100/$num_raw)" |bc)
+    pc_aft_trim=$(echo "scale=2; ($num_trim*100/$num_uniq)" |bc)
     pc_mapped=$(echo "scale=2; ($num_map*100/$num_trim)" |bc)
     genome_cov=$(echo "scale=2; (100-($zero_cov*100/$sites))" |bc)
 


### PR DESCRIPTION
Added a couple of minor changes to fix edge cases where data is outside of normal expectations.
One addresses issue #11 and the other expresses %trimmed reads as a proportion of the unique reads rather than raw reads.  This is because a dataset could have a high proportion of duplicated reads, but still be of high quality.