### PR TITLE
Unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,13 @@ jobs:
       - build-and-push:
           tag: latest
 
+  unittests:
+    executor: nf-pipeline
+    steps:
+      - run: |
+          cd /BovTB-nf/
+          python tests/jobs/unit_tests.py
+
   tinyreads:
     executor: nf-pipeline
     steps:
@@ -104,6 +111,10 @@ workflows:
           filters:
             branches:
               only: master
+
+      - unittests:
+          requires:
+            - build
 
       - tinyreads:
           requires:

--- a/tests/jobs/unit_tests.py
+++ b/tests/jobs/unit_tests.py
@@ -1,0 +1,4 @@
+import unittest
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/jobs/unit_tests.py
+++ b/tests/jobs/unit_tests.py
@@ -1,4 +1,26 @@
+#!/usr/local/bin/python
+
+""" unit_tests.py: 
+		This file runs unit tests for the pipeline. 
+		Each unit test should be quick to run (ie. less than second). 
+		Tests that have a long run time should be an .circleci job.
+"""
+
 import unittest
+import subprocess
+
+class TestPipeline(unittest.TestCase):
+    def test_deduplicate(self):
+        """
+            This introductory unit test asserts the deduplicate prcocess works on tinyreads.
+            It currently fails because the depend_path is wrong.
+        """
+        depend_path = './'
+        pair_id = 'tests/data/tinyreads/tinyreads'
+
+        return_code = subprocess.run(['bash', '-e', './bin/deduplicate.bash', depend_path, pair_id]).returncode
+
+        self.assertEqual(return_code, 0)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/jobs/unit_tests.py
+++ b/tests/jobs/unit_tests.py
@@ -12,13 +12,13 @@ import subprocess
 class TestPipeline(unittest.TestCase):
     def test_deduplicate(self):
         """
-            This introductory unit test asserts the deduplicate prcocess works on tinyreads.
-            It currently fails because the depend_path is wrong.
+            This introductory unit test asserts the deduplicate process completes on tinyreads without errors.
+            It currently fails on line 23 because the depend_path arg is not supplied.
+            In a future PR, I would like to fix this by putting FastUniq on the Linux search path.
         """
-        depend_path = './'
         pair_id = 'tests/data/tinyreads/tinyreads'
 
-        return_code = subprocess.run(['bash', '-e', './bin/deduplicate.bash', depend_path, pair_id]).returncode
+        return_code = subprocess.run(['bash', '-e', './bin/deduplicate.bash', pair_id]).returncode
 
         self.assertEqual(return_code, 0)
 

--- a/tests/jobs/unit_tests.py
+++ b/tests/jobs/unit_tests.py
@@ -2,8 +2,8 @@
 
 """ unit_tests.py: 
 		This file runs unit tests for the pipeline. 
-		Each unit test should be quick to run (ie. less than second). 
-		Tests that have a long run time should be an .circleci job.
+		Each unit test should be quick to run (ie. milliseconds typically, but certainly less than second) 
+		Tests that have a long run time should simplified, mocked, or be a .circleci job.
 """
 
 import unittest


### PR DESCRIPTION
Introducing unit tests with python
--------

In this PR:
- A spiel on testing (read below)
- An introductory unit test in `unit_tests.py`. The test asserts `deduplicate.bash` returns a non-zero exit code on `tinyreads`. The test currently fails because the `depend_path` is not supplied. I plan to fix this in a future PR by putting `FastUniq` on the linux search path arg. Lmk if you'd prefer a different implementation.
- `.circleci` job for the unit tests, which runs in parallel with the `tinyreads` job. This way, we are not prevented from gaining feedback on work in progress features (see images below). This structure also supports Test Driven Development (TDD).

Testing Spiel
------

Unit tests yield robust, quality code by ensuring individual software components behave as intended. By having many unit tests that are individually very quick to run (often milliseconds, but less than a second certainly), we assert the typical response and protect against edge cases as well as bad inputs. As a result, developers that write unit tests tend to develop faster, despite having to write additional unit test code. Totally worth the learning investment ;)

TDD takes this philosophy one step further, by writing the unit tests up front before the actual feature is finished. It's a top-down approach, where you start by writing unit tests that define how the feature will respond, and then write code that makes the tests pass. Think of `test_deduplicate()` in `unit_tests.py` as a simplified example of TDD: I am first writing a test that doesn't pass, because it shows how I really want the script to behave. 

Personally, I do like TDD for features when it's really clear from the onset how it should work. Though, I sometimes find TDD cumbersome for exploratory work.

In python, unit test cases are functions. The case passes if the function exits without an exception being thrown. Otherwise it passes. 

Tests that take a long time to run should either be simplified, [mocked](https://realpython.com/python-mock-library/), or turned into an end-to-end integration tests, similar to the circleci jobs we have already.

<img width="1440" alt="structure" src="https://user-images.githubusercontent.com/6979169/104333182-dd7c7880-54e8-11eb-9d48-e9a6853721a5.png">

<img width="1440" alt="Screenshot 2021-01-12 at 11 42 08" src="https://user-images.githubusercontent.com/6979169/104333250-ecfbc180-54e8-11eb-86b0-cbc9dc48ba54.png">
