### PR TITLE
Fix id non bovis

### DIFF
--- a/bTB-WGS_process.nf
+++ b/bTB-WGS_process.nf
@@ -312,7 +312,7 @@ process IDnonbovis{
 	file("${pair_id}_bovis.csv") optional true into QueryBovis
 
 	"""
-	idNonBovis.bash $pair_id
+	idNonBovis.bash $pair_id $kraken2db $params.lowmem
 	"""
 }
 

--- a/bin/idNonBovis.bash
+++ b/bin/idNonBovis.bash
@@ -6,10 +6,12 @@
 # Presence / absence of M.bovis is also determined by parsing Bracken output
 
 pair_id=$1
+kraken2db=$2
+lowmem=$3
 
 outcome=$(cat outcome.txt)
 if [ $outcome != "Pass" ]; then
-kraken2 --threads 2 --quick $params.lowmem --db $kraken2db --output - --report ${pair_id}_"$outcome"_kraken2.tab --paired ${pair_id}_trim_R1.fastq  ${pair_id}_trim_R2.fastq 
+kraken2 --threads 2 --quick $lowmem --db $kraken2db --output - --report ${pair_id}_"$outcome"_kraken2.tab --paired ${pair_id}_trim_R1.fastq  ${pair_id}_trim_R2.fastq 
 
 # HACK: (AF) Ignore Bracken errors. Better to handle output from Kraken and have unit tests, 
 # but easier let the pipeline pass while we are setting up validation tests.. 
@@ -20,7 +22,7 @@ sed 1d ${pair_id}_"$outcome"_bracken.out | sort -t $'t' -k7,7 -nr - | head -20 >
 bracken -d $kraken2db -r150 -l S1 -i ${pair_id}_"${outcome}"_kraken2.tab -o ${pair_id}_"$outcome"-S1_bracken.out
 ( sed -u 1q; sort -t $'t' -k7,7 -nr ) < ${pair_id}_"$outcome"-S1_bracken.out > ${pair_id}_"$outcome"-S1_brackensort.tab
 BovPos=$(grep 'variant bovis' ${pair_id}_"$outcome"-S1_brackensort.tab |
- awk '{print \$1" "\$2" "\$3" "\$4","\$9","(\$10*100)}' || true)
+ awk '{print $1" "$2" "$3" "$4","$9","($10*100)}' || true)
 echo "Sample,ID,TotalReads,Abundance" > ${pair_id}_bovis.csv
 echo "${pair_id},"$BovPos"" >> ${pair_id}_bovis.csv
 

--- a/bin/idNonBovis.bash
+++ b/bin/idNonBovis.bash
@@ -22,7 +22,7 @@ sed 1d ${pair_id}_"$outcome"_bracken.out | sort -t $'t' -k7,7 -nr - | head -20 >
 bracken -d $kraken2db -r150 -l S1 -i ${pair_id}_"${outcome}"_kraken2.tab -o ${pair_id}_"$outcome"-S1_bracken.out
 ( sed -u 1q; sort -t $'t' -k7,7 -nr ) < ${pair_id}_"$outcome"-S1_bracken.out > ${pair_id}_"$outcome"-S1_brackensort.tab
 BovPos=$(grep 'variant bovis' ${pair_id}_"$outcome"-S1_brackensort.tab |
- awk '{print $1" "$2" "$3" "$4","$9","($10*100)}' || true)
+ awk '{printf $1" "$2" "$3" "$4","$9"," "%.3f", ($10*100)}' || true)
 echo "Sample,ID,TotalReads,Abundance" > ${pair_id}_bovis.csv
 echo "${pair_id},"$BovPos"" >> ${pair_id}_bovis.csv
 

--- a/bin/readStats.bash
+++ b/bin/readStats.bash
@@ -20,8 +20,8 @@ pair_id=$1
     trim_R1=$(( $(cat ${pair_id}_trim_R1.fastq | wc -l) / 4 )) # counts number of reads in file
     num_map=$(samtools view -c ${pair_id}.mapped.sorted.bam) # samtools counts the number of mapped reads
     samtools depth -a ${pair_id}.mapped.sorted.bam > depth.txt # samtools outputs depth at each position
-    avg_depth=$(awk '{sum+=$3} END { print sum/NR}' depth.txt)
-    zero_cov=$(awk 'BEGIN (count=0) $3<1 {++count} END {print count}' depth.txt)
+    avg_depth=$(awk '{sum+=$3} END { printf "%.3f", sum/NR}' depth.txt)
+    zero_cov=$(awk 'BEGIN {count=0} $3<1 {++count} END {print count}' depth.txt)
     sites=$(awk '{++count} END {print count}' depth.txt)
     rm depth.txt
     

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -126,7 +126,7 @@ RUN wget https://github.com/jenniferlu717/Bracken/archive/v2.6.0.tar.gz && \
     cd Bracken-2.6.0 && \
     sh ./install_bracken.sh ../bracken && \
     cd .. && \
-    ln -s $BIOTOOLS_PATH/Bracken-2.6.0/bracken /usr/local/bin/bracken
+    ln -s $BIOTOOLS_PATH/Bracken-2.6.0/bracken /usr/local/bin/bracken \
     ln -s $BIOTOOLS_PATH/Bracken-2.6.0/src /usr/local/bin/src
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -126,7 +126,7 @@ RUN wget https://github.com/jenniferlu717/Bracken/archive/v2.6.0.tar.gz && \
     cd Bracken-2.6.0 && \
     sh ./install_bracken.sh ../bracken && \
     cd .. && \
-    ln -s $BIOTOOLS_PATH/Bracken-2.6.0/bracken /usr/local/bin/bracken \
+    ln -s $BIOTOOLS_PATH/Bracken-2.6.0/bracken /usr/local/bin/bracken && \
     ln -s $BIOTOOLS_PATH/Bracken-2.6.0/src /usr/local/bin/src
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -120,6 +120,8 @@ RUN wget https://genome-idx.s3.amazonaws.com/kraken/minikraken2_v1_8GB_201904.tg
     rm -f minikraken2_v1_8GB_201904.tgz
 
 # bracken
+# Need to look at alternate solutions running bracken. This works, and is the suggested approach, 
+# but there must be a better solution than adding a symlink to the bracken src/ directory
 RUN wget https://github.com/jenniferlu717/Bracken/archive/v2.6.0.tar.gz && \
     tar xzf v2.6.0.tar.gz && \
     rm -f v2.6.0.tar.gz && \
@@ -128,7 +130,6 @@ RUN wget https://github.com/jenniferlu717/Bracken/archive/v2.6.0.tar.gz && \
     cd .. && \
     ln -s $BIOTOOLS_PATH/Bracken-2.6.0/bracken /usr/local/bin/bracken && \
     ln -s $BIOTOOLS_PATH/Bracken-2.6.0/src /usr/local/bin/src
-
 
 # Install nextflow.
 COPY ./docker/install_nextflow-20.7.1.bash ./install_nextflow.bash

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -127,6 +127,7 @@ RUN wget https://github.com/jenniferlu717/Bracken/archive/v2.6.0.tar.gz && \
     sh ./install_bracken.sh ../bracken && \
     cd .. && \
     ln -s $BIOTOOLS_PATH/Bracken-2.6.0/bracken /usr/local/bin/bracken
+    ln -s $BIOTOOLS_PATH/Bracken-2.6.0/src /usr/local/bin/src
 
 
 # Install nextflow.

--- a/tests/jobs/unit_tests.py
+++ b/tests/jobs/unit_tests.py
@@ -64,5 +64,15 @@ class TestPipeline(unittest.TestCase):
         # Test
         self.assertBashScript(0, ['./bin/mask.bash', pair_id, rpt_mask])
 
+    def test_combinecsv(self):
+        """
+            This unit test checks the correct merging of CSV files and intepretation of thresholds
+        """
+        csv1 = 'tests/data/assigned-test1.csv'
+        csv2 = 'tests/data/bovpos_test2.csv'
+
+        return_code = subprocess.run(['bash', '-e', './bin/CombineCsv.py', csv1, csv2]).returncode
+        self.assertEqual(return_code, 0)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/jobs/unit_tests.py
+++ b/tests/jobs/unit_tests.py
@@ -64,15 +64,5 @@ class TestPipeline(unittest.TestCase):
         # Test
         self.assertBashScript(0, ['./bin/mask.bash', pair_id, rpt_mask])
 
-    def test_combinecsv(self):
-        """
-            This unit test checks the correct merging of CSV files and intepretation of thresholds
-        """
-        csv1 = 'tests/data/assigned-test1.csv'
-        csv2 = 'tests/data/bovpos_test2.csv'
-
-        return_code = subprocess.run(['bash', '-e', './bin/CombineCsv.py', csv1, csv2]).returncode
-        self.assertEqual(return_code, 0)
-
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR fixes an issue that I noticed where the idNonBovis was not running correctly after being moved to a standalone script.  I picked this up running samples which do not 'Pass'.  There were a number of problems, but they have all been fixed:
- Additional parameters (kraken2db and lowmem) were required when calling the script - without them kraken fails and does not produce the output for bracken.  
- Bracken also required the kraken2db parameter (and the kraken output!).  
- In addition to bracken being linked in /usr/local/bin, the bracken/src/ directory also need to be linked.
- the awk command failed as the variables were escape (which was essential to get it running as a script embedded in nextflow)
